### PR TITLE
add firo-network support

### DIFF
--- a/.changeset/bright-stingrays-shout.md
+++ b/.changeset/bright-stingrays-shout.md
@@ -1,0 +1,5 @@
+---
+'@rosen-chains/firo-rpc': minor
+---
+
+Add Firo network

--- a/.changeset/bright-stingrays-shout.md
+++ b/.changeset/bright-stingrays-shout.md
@@ -2,4 +2,4 @@
 '@rosen-chains/firo-rpc': minor
 ---
 
-Add Firo network
+Initialize the package

--- a/package-lock.json
+++ b/package-lock.json
@@ -5068,6 +5068,10 @@
       "resolved": "packages/chains/firo",
       "link": true
     },
+    "node_modules/@rosen-chains/firo-rpc": {
+      "resolved": "packages/networks/firo-rpc",
+      "link": true
+    },
     "node_modules/@rosen-clients/axios": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rosen-clients/axios/-/axios-1.1.1.tgz",
@@ -18159,6 +18163,28 @@
         "@rosen-chains/abstract-chain": "^15.0.2",
         "@rosen-chains/evm": "^9.0.2",
         "ethers": "6.16.0"
+      },
+      "engines": {
+        "node": ">=22.18.0",
+        "npm": "11.6.2"
+      }
+    },
+    "packages/networks/firo-rpc": {
+      "name": "@rosen-chains/firo-rpc",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@rosen-bridge/abstract-logger": "^4.0.0",
+        "@rosen-bridge/json-bigint": "^1.1.0",
+        "@rosen-chains/abstract-chain": "^15.0.1",
+        "@rosen-chains/firo": "^0.0.0",
+        "@rosen-clients/rate-limited-axios": "^1.1.0",
+        "bitcoinjs-lib": "^6.1.5"
+      },
+      "devDependencies": {
+        "@vitest/coverage-istanbul": "^3.1.4",
+        "tsx": "^4.20.5",
+        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=22.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18176,15 +18176,10 @@
       "dependencies": {
         "@rosen-bridge/abstract-logger": "^4.0.0",
         "@rosen-bridge/json-bigint": "^1.1.0",
-        "@rosen-chains/abstract-chain": "^15.0.1",
+        "@rosen-chains/abstract-chain": "^15.0.2",
         "@rosen-chains/firo": "^0.0.0",
-        "@rosen-clients/rate-limited-axios": "^1.1.0",
+        "@rosen-clients/rate-limited-axios": "^1.1.1",
         "bitcoinjs-lib": "^6.1.5"
-      },
-      "devDependencies": {
-        "@vitest/coverage-istanbul": "^3.1.4",
-        "tsx": "^4.20.5",
-        "vitest": "^3.1.4"
       },
       "engines": {
         "node": ">=22.18.0",

--- a/packages/networks/firo-rpc/README.md
+++ b/packages/networks/firo-rpc/README.md
@@ -1,0 +1,26 @@
+# @rosen-chains/firo-rpc
+
+## Table of contents
+
+- [@rosen-chains/firo-rpc](#rosen-chainsfiro-rpc)
+  - [Table of contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Installation](#installation)
+
+## Introduction
+
+A package to be used as network api provider for @rosen-chains/firo package
+
+## Installation
+
+npm:
+
+```sh
+npm i @rosen-chains/firo-rpc
+```
+
+yarn:
+
+```sh
+yarn add @rosen-chains/firo-rpc
+```

--- a/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
+++ b/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
@@ -8,12 +8,14 @@ import {
   FailedError,
   NetworkError,
   UnexpectedApiError,
+  PaymentTransaction,
 } from '@rosen-chains/abstract-chain';
 import {
   AbstractFiroNetwork,
   FiroTx,
   FiroUtxo,
   CONFIRMATION_TARGET,
+  FIRO_NETWORK,
 } from '@rosen-chains/firo';
 import RateLimitedAxios from '@rosen-clients/rate-limited-axios';
 
@@ -23,13 +25,25 @@ import {
   FiroBlockSummary,
   FiroChainInfo,
   RpcAuth,
+  FiroRpcUtxo,
 } from './types';
 
 class FiroRpcNetwork extends AbstractFiroNetwork {
   protected client; // TODO: specify the type (local:ergo/rosen-bridge/network-client#26)
+  private getSavedTransactionById: (
+    txId: string,
+  ) => Promise<PaymentTransaction | undefined>;
 
-  constructor(url: string, logger?: AbstractLogger, auth?: RpcAuth) {
+  constructor(
+    url: string,
+    getSavedTransactionById: (
+      txId: string,
+    ) => Promise<PaymentTransaction | undefined>,
+    logger?: AbstractLogger,
+    auth?: RpcAuth,
+  ) {
     super(logger);
+    this.getSavedTransactionById = getSavedTransactionById;
 
     const headers = { 'Content-Type': 'application/json' };
 
@@ -101,7 +115,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       this.validateResponseId(randomId, response.data.id);
 
       const chainInfo: FiroChainInfo = response.data.result;
-      this.logger?.debug(
+      this.logger.debug(
         `Requested 'getblockchaininfo'. Response: ${JsonBigInt.stringify(
           chainInfo,
         )}`,
@@ -140,7 +154,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       this.validateResponseId(randomId, response.data.id);
 
       const blockData: FiroBlockSummary = response.data.result;
-      this.logger?.debug(
+      this.logger.debug(
         `Requested 'getblock' for blockId [${blockId}]. Response: ${JsonBigInt.stringify(
           blockData,
         )}`,
@@ -179,7 +193,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       this.validateResponseId(randomId, response.data.id);
 
       const blockData: FiroBlockSummary = response.data.result;
-      this.logger?.debug(
+      this.logger.debug(
         `Requested 'getblock' for blockId [${blockId}]. Response: ${JsonBigInt.stringify(
           blockData,
         )}`,
@@ -227,7 +241,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       this.validateResponseId(randomId, response.data.id);
 
       const tx: FiroRpcTransaction = response.data.result;
-      this.logger?.debug(
+      this.logger.debug(
         `Requested 'getrawtransaction' for txId [${transactionId}]. Response: ${JsonBigInt.stringify(
           tx,
         )}`,
@@ -281,7 +295,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
 
       this.validateResponseId(randomId, response.data.id);
 
-      this.logger?.debug(
+      this.logger.debug(
         `Submitted transaction. Response: ${JsonBigInt.stringify(
           response.data,
         )}`,
@@ -407,7 +421,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       const feeSatoshis = this.convertToSatoshis(response.data.result.feerate);
       const feeRate = Number(feeSatoshis) / 1024;
 
-      this.logger?.debug(
+      this.logger.debug(
         `Requested 'estimatesmartfee'. Response: ${JsonBigInt.stringify(
           response.data.result,
         )}`,
@@ -486,7 +500,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       this.validateResponseId(randomId, response.data.id);
 
       const txHex: string = response.data.result;
-      this.logger?.debug(`Requested transaction hex for txId [${txId}].`);
+      this.logger.debug(`Requested transaction hex for txId [${txId}].`);
 
       return txHex;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -527,14 +541,13 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
 
       this.validateResponseId(randomId, response.data.id);
 
-      const utxos: Array<{
-        txid: string;
-        vout: number;
-        address: string;
-        scriptPubKey: string;
-        amount: number;
-        confirmations: number;
-      }> = response.data.result;
+      const utxos: Array<FiroRpcUtxo> = response.data.result;
+
+      this.logger.debug(
+        `Requested 'listunspent' for address [${address}]. Response: ${JsonBigInt.stringify(
+          utxos,
+        )}`,
+      );
 
       // Convert to FiroUtxo format and apply pagination
       const firoUtxos = utxos.slice(offset, offset + limit).map((utxo) => ({
@@ -543,7 +556,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
         value: this.convertToSatoshis(utxo.amount),
       }));
 
-      this.logger?.debug(
+      this.logger.debug(
         `Requested 'listunspent' for address [${address}]. Found ${utxos.length} UTXOs, returning ${firoUtxos.length}.`,
       );
 
@@ -564,11 +577,13 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
   };
 
   /**
-   * gets the number of confirmations for a transaction
-   * @param transactionId the transaction id
+   * gets the number of confirmations for a transaction (only supports signed tx id)
+   * @param transactionId the signed transaction id
    * @returns the number of confirmations
    */
-  getTxConfirmation = async (transactionId: string): Promise<number> => {
+  protected getTxConfirmationSigned = async (
+    transactionId: string,
+  ): Promise<number> => {
     const randomId = this.generateRandomId();
     try {
       const response = await this.client.post<JsonRpcResult>('', {
@@ -581,11 +596,23 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
 
       const tx: FiroRpcTransaction = response.data.result;
 
-      return tx.confirmations || 0;
+      this.logger.debug(
+        `Requested 'getrawtransaction' for txId [${transactionId}]. Response: ${JsonBigInt.stringify(
+          tx,
+        )}`,
+      );
+
+      // Return -1 for unconfirmed transactions (confirmations undefined or 0)
+      return tx.confirmations && tx.confirmations > 0 ? tx.confirmations : -1;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       const baseError = `Failed to get transaction confirmations for [${transactionId}] from Firo RPC: `;
-      if (e.response) {
+      if (e.response && e.response.data && e.response.data.error) {
+        if (e.response.data.error.code === -5) {
+          // Transaction not found
+          this.logger.debug(`tx [${transactionId}] is not found`);
+          return -1;
+        }
         throw new FailedError(
           baseError + JsonBigInt.stringify(e.response.data),
         );
@@ -595,6 +622,16 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
         throw new UnexpectedApiError(baseError + e.message);
       }
     }
+  };
+
+  /**
+   * gets confirmation for a transaction (returns -1 if tx is not mined or found)
+   * @param transactionId the transaction id (supports both real signed tx id and unsigned tx id)
+   * @returns the transaction confirmation (returns -1 if tx is not mined or found)
+   */
+  getTxConfirmation = async (transactionId: string): Promise<number> => {
+    const realTxId = await this.getActualTxId(transactionId);
+    return await this.getTxConfirmationSigned(realTxId);
   };
 
   /**
@@ -621,14 +658,16 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
 
       const utxos: Array<{ amount: number }> = response.data.result;
 
+      this.logger.debug(
+        `Requested 'listunspent' for address [${address}]. Response: ${JsonBigInt.stringify(
+          utxos,
+        )}`,
+      );
+
       // Sum up all UTXO values
       const totalSatoshis = utxos.reduce(
         (sum, utxo) => sum + this.convertToSatoshis(utxo.amount),
         0n,
-      );
-
-      this.logger?.debug(
-        `Requested address assets for [${address}]. Total: ${totalSatoshis} satoshis.`,
       );
 
       return {
@@ -651,13 +690,187 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
   };
 
   /**
+   * Attempts to find which transaction spent a specific UTXO using Firo's address indexing
+   * @param index the output index that was spent
+   * @param txId the transaction ID containing the output
+   * @returns the transaction that spent the UTXO, or undefined if not found
+   */
+  protected getSpentTransactionByInputId = async (
+    index: number,
+    txId: string,
+  ): Promise<FiroTx | undefined> => {
+    try {
+      // Get the original transaction to examine the spent output
+      const originalTx = await this.getTransaction(txId, '');
+      if (!originalTx.outputs[index]) {
+        return undefined;
+      }
+
+      // Get recent mempool transactions that might spend our UTXO
+      const mempoolTxIds = await this.client.post<JsonRpcResult>('', {
+        method: 'getrawmempool',
+        id: this.generateRandomId(),
+        params: [false], // non-verbose
+      });
+
+      const allTxIds: string[] = mempoolTxIds.data.result || [];
+
+      // Check each transaction to see if it spends our UTXO
+      for (const candidateTxId of allTxIds) {
+        try {
+          const candidateTx = await this.getTransaction(candidateTxId, '');
+
+          // Check if any input spends our specific UTXO
+          const spendsOurUtxo = candidateTx.inputs.some(
+            (input) => input.txId === txId && input.index === index,
+          );
+
+          if (spendsOurUtxo) {
+            return candidateTx;
+          }
+        } catch {
+          // Skip transactions we can't fetch
+          continue;
+        }
+      }
+
+      return undefined;
+    } catch (error) {
+      this.logger.debug(
+        `Failed to find spending transaction for UTXO ${txId}:${index} using RPC lookup: ${error}`,
+      );
+      return undefined;
+    }
+  };
+
+  /**
+   * Attempts to extract signed transaction ID directly from PSBT
+   * @param psbt the PSBT containing the transaction
+   * @returns the signed transaction ID, or undefined if extraction fails
+   */
+  protected extractActualTxIdFromPsbt = async (
+    psbt: Psbt,
+  ): Promise<string | undefined> => {
+    try {
+      return psbt.extractTransaction(true).getId();
+    } catch (error) {
+      this.logger.debug(
+        `Failed to extract signed transaction ID from PSBT: ${error}`,
+      );
+      return undefined;
+    }
+  };
+
+  /**
+   * Attempts to find signed transaction ID using RPC lookup of spending transactions
+   * @param psbt the PSBT containing the unsigned transaction
+   * @returns the signed transaction ID, or undefined if not found
+   */
+  protected extractActualTxIdWithRpcLookup = async (
+    psbt: Psbt,
+  ): Promise<string | undefined> => {
+    try {
+      if (psbt.txInputs.length === 0) {
+        return undefined;
+      }
+
+      // Use the first input to find the spending transaction
+      const firstInput = psbt.txInputs[0];
+      const inputTxId = Buffer.from(firstInput.hash.reverse()).toString('hex');
+      const inputIndex = firstInput.index;
+
+      const spentTx = await this.getSpentTransactionByInputId(
+        inputIndex,
+        inputTxId,
+      );
+      if (!spentTx) {
+        return undefined;
+      }
+
+      // Verify this is the same transaction by comparing inputs and outputs
+      const sameInputs = psbt.txInputs.every(
+        (input, i) =>
+          spentTx.inputs[i]?.txId ===
+            Buffer.from(input.hash.reverse()).toString('hex') &&
+          spentTx.inputs[i]?.index === input.index,
+      );
+
+      const sameOutputs = psbt.txOutputs.every(
+        (output, i) =>
+          spentTx.outputs[i]?.scriptPubKey ===
+            Buffer.from(output.script).toString('hex') &&
+          spentTx.outputs[i]?.value === BigInt(output.value),
+      );
+
+      if (sameInputs && sameOutputs) {
+        return spentTx.id;
+      }
+
+      return undefined;
+    } catch (error) {
+      this.logger.debug(
+        `Failed to find signed transaction ID using RPC lookup: ${error}`,
+      );
+      return undefined;
+    }
+  };
+
+  /**
    * gets the actual transaction ID from a transaction hash
-   * For Firo (like Bitcoin), the transaction ID and hash are the same
-   * @param hash the transaction hash
-   * @returns the actual transaction ID
+   * For unsigned transactions, finds the corresponding signed transaction ID
+   *
+   * Uses a two-stage approach:
+   * 1. First attempts direct extraction from PSBT
+   * 2. Falls back to RPC-based lookup using Firo's address indexing
+   *
+   * @param hash the transaction hash (can be unsigned or signed)
+   * @returns the actual signed transaction ID
    */
   getActualTxId = async (hash: string): Promise<string> => {
-    return hash;
+    let actualTxId = hash;
+    try {
+      const realPaymentTx = await this.getSavedTransactionById(hash);
+
+      if (realPaymentTx) {
+        const realTx = Psbt.fromBuffer(Buffer.from(realPaymentTx.txBytes), {
+          network: FIRO_NETWORK,
+        });
+
+        // Method 1: Try direct PSBT extraction
+        const directExtraction = await this.extractActualTxIdFromPsbt(realTx);
+        if (directExtraction) {
+          actualTxId = directExtraction;
+        } else {
+          // Method 2: Fallback to RPC lookup
+          this.logger.debug(
+            `Direct PSBT extraction failed for hash [${hash}], attempting RPC lookup...`,
+          );
+
+          const rpcLookup = await this.extractActualTxIdWithRpcLookup(realTx);
+          if (rpcLookup) {
+            actualTxId = rpcLookup;
+          } else {
+            this.logger.debug(
+              `Both extraction methods failed for hash [${hash}], using original hash as fallback`,
+            );
+          }
+        }
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get actual txId for tx [${hash}] which was found in the database: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+
+    return actualTxId;
   };
 }
 

--- a/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
+++ b/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
@@ -614,7 +614,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
       const response = await this.client.post<JsonRpcResult>('', {
         method: 'listunspent',
         id: randomId,
-        params: [0, 9999999, [address]], // minconf=0 to include mempool
+        params: [1, 9999999, [address]], // minconf=1 to include only confirmed UTXOs
       });
 
       this.validateResponseId(randomId, response.data.id);

--- a/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
+++ b/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
@@ -1,0 +1,664 @@
+import { Psbt } from 'bitcoinjs-lib';
+import { randomBytes } from 'crypto';
+
+import { AbstractLogger } from '@rosen-bridge/abstract-logger';
+import JsonBigInt from '@rosen-bridge/json-bigint';
+import {
+  BlockInfo,
+  FailedError,
+  NetworkError,
+  UnexpectedApiError,
+} from '@rosen-chains/abstract-chain';
+import {
+  AbstractFiroNetwork,
+  FiroTx,
+  FiroUtxo,
+  CONFIRMATION_TARGET,
+} from '@rosen-chains/firo';
+import RateLimitedAxios from '@rosen-clients/rate-limited-axios';
+
+import {
+  FiroRpcTransaction,
+  JsonRpcResult,
+  FiroBlockSummary,
+  FiroChainInfo,
+  RpcAuth,
+} from './types';
+
+class FiroRpcNetwork extends AbstractFiroNetwork {
+  protected client; // TODO: specify the type (local:ergo/rosen-bridge/network-client#26)
+
+  constructor(url: string, logger?: AbstractLogger, auth?: RpcAuth) {
+    super(logger);
+
+    const headers = { 'Content-Type': 'application/json' };
+
+    // Add API key to headers if provided
+    if (auth?.apiKey) {
+      Object.assign(headers, { 'x-api-key': auth.apiKey });
+    }
+
+    const authConfig =
+      auth?.username || auth?.password
+        ? {
+            auth: {
+              username: auth?.username || '',
+              password: auth?.password || '',
+            },
+          }
+        : {};
+
+    this.client = RateLimitedAxios.create({
+      baseURL: url,
+      headers: headers,
+      ...authConfig,
+    });
+  }
+
+  private generateRandomId = () => randomBytes(32).toString('hex');
+
+  /**
+   * Validates that the response ID matches the request ID
+   * @param requestId the request ID
+   * @param responseId the response ID
+   * @throws UnexpectedApiError if IDs don't match
+   */
+  protected validateResponseId = (
+    requestId: string,
+    responseId: string,
+  ): void => {
+    if (responseId !== requestId) {
+      throw new UnexpectedApiError(
+        `Request and response id are different ['${requestId}' != '${responseId}']`,
+      );
+    }
+  };
+
+  /**
+   * Converts FIRO value to satoshis using string manipulation to avoid floating-point issues
+   * @param value FIRO value as a number
+   * @returns satoshis as a bigint
+   */
+  protected convertToSatoshis = (value: number): bigint => {
+    const parts = value.toString().split('.');
+    const part1 = ((parts[1] ?? '') + '0'.repeat(8)).substring(0, 8);
+    return BigInt((parts[0] === '0' ? '' : parts[0]) + part1);
+  };
+
+  /**
+   * gets the blockchain height
+   * @returns the blockchain height
+   */
+  getHeight = async (): Promise<number> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getblockchaininfo',
+        id: randomId,
+        params: [],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const chainInfo: FiroChainInfo = response.data.result;
+      this.logger?.debug(
+        `Requested 'getblockchaininfo'. Response: ${JsonBigInt.stringify(
+          chainInfo,
+        )}`,
+      );
+
+      return chainInfo.blocks;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to fetch current height from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + `${JsonBigInt.stringify(e.response.data)}`,
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets id of all transactions in the given block
+   * @param blockId the block id
+   * @returns list of the transaction ids in the block
+   */
+  getBlockTransactionIds = async (blockId: string): Promise<Array<string>> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getblock',
+        id: randomId,
+        params: [blockId, true],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const blockData: FiroBlockSummary = response.data.result;
+      this.logger?.debug(
+        `Requested 'getblock' for blockId [${blockId}]. Response: ${JsonBigInt.stringify(
+          blockData,
+        )}`,
+      );
+
+      return blockData.tx;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get block [${blockId}] transaction ids from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets info of the given block
+   * @param blockId the block id
+   * @returns the block info
+   */
+  getBlockInfo = async (blockId: string): Promise<BlockInfo> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getblock',
+        id: randomId,
+        params: [blockId, true],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const blockData: FiroBlockSummary = response.data.result;
+      this.logger?.debug(
+        `Requested 'getblock' for blockId [${blockId}]. Response: ${JsonBigInt.stringify(
+          blockData,
+        )}`,
+      );
+
+      return {
+        hash: blockData.hash,
+        parentHash: blockData.previousblockhash,
+        height: blockData.height,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get block [${blockId}] info from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets a transaction
+   * @param transactionId the transaction id
+   * @param blockId the block id
+   * @returns the transaction
+   */
+  getTransaction = async (
+    transactionId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    blockId: string,
+  ): Promise<FiroTx> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getrawtransaction',
+        id: randomId,
+        params: [transactionId, true],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const tx: FiroRpcTransaction = response.data.result;
+      this.logger?.debug(
+        `Requested 'getrawtransaction' for txId [${transactionId}]. Response: ${JsonBigInt.stringify(
+          tx,
+        )}`,
+      );
+
+      // Transform the RPC transaction to the expected FiroTx format
+      const firoTx: FiroTx = {
+        id: tx.txid,
+        inputs: tx.vin.map((input) => ({
+          txId: input.txid || '', // Coinbase txs don't have txid
+          index: input.vout ?? -1, // Coinbase txs don't have vout
+          scriptPubKey: input.scriptSig?.hex || input.coinbase || '', // Coinbase uses coinbase field
+        })),
+        outputs: tx.vout.map((output) => ({
+          value: this.convertToSatoshis(output.value),
+          scriptPubKey: output.scriptPubKey.hex,
+        })),
+      };
+
+      return firoTx;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get transaction [${transactionId}] from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * submits a transaction
+   * @param transaction the transaction
+   */
+  submitTransaction = async (transaction: Psbt): Promise<void> => {
+    // Extract the raw transaction hex
+    const txHex = transaction.extractTransaction(true).toHex();
+
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'sendrawtransaction',
+        id: randomId,
+        params: [txHex],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      this.logger?.debug(
+        `Submitted transaction. Response: ${JsonBigInt.stringify(
+          response.data,
+        )}`,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to submit transaction to Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * checks if a box is unspent and valid
+   * @param boxId the box id
+   * @returns true if the box is unspent and valid
+   */
+  isBoxUnspentAndValid = async (boxId: string): Promise<boolean> => {
+    const [txId, outputIndexStr] = boxId.split('.');
+    const outputIndex = parseInt(outputIndexStr);
+
+    const randomId = this.generateRandomId();
+    try {
+      // Check if the output is spent
+      const listUnspentResponse = await this.client.post<JsonRpcResult>('', {
+        method: 'gettxout',
+        id: randomId,
+        params: [txId, outputIndex, false], // txid, n, include_mempool
+      });
+
+      this.validateResponseId(randomId, listUnspentResponse.data.id);
+
+      // If the result is null, the output is spent
+      return listUnspentResponse.data.result !== null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to check if box [${boxId}] is unspent from Firo RPC: `;
+      if (e.response && e.response.data && e.response.data.error) {
+        if (e.response.data.error.code === -5) {
+          // No such transaction error
+          return false;
+        }
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets a utxo
+   * @param boxId the box id
+   * @returns the utxo
+   */
+  getUtxo = async (boxId: string): Promise<FiroUtxo> => {
+    const [txId, outputIndexStr] = boxId.split('.');
+    const outputIndex = parseInt(outputIndexStr);
+
+    const randomId = this.generateRandomId();
+    try {
+      // Get the transaction to extract the UTXO information
+      const txResponse = await this.client.post<JsonRpcResult>('', {
+        method: 'getrawtransaction',
+        id: randomId,
+        params: [txId, true],
+      });
+
+      this.validateResponseId(randomId, txResponse.data.id);
+
+      const tx: FiroRpcTransaction = txResponse.data.result;
+
+      if (!tx || outputIndex >= tx.vout.length) {
+        throw new FailedError(`UTXO with boxId [${boxId}] not found`);
+      }
+
+      const output = tx.vout[outputIndex];
+
+      return {
+        txId: txId,
+        index: outputIndex,
+        value: this.convertToSatoshis(output.value),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get UTXO [${boxId}] from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets the fee ratio
+   * @returns the fee ratio in satoshis/byte
+   */
+  getFeeRatio = async (): Promise<number> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'estimatesmartfee',
+        id: randomId,
+        params: [CONFIRMATION_TARGET], // Number of blocks to target for confirmation
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+      const feeSatoshis = this.convertToSatoshis(response.data.result.feerate);
+      const feeRate = Number(feeSatoshis) / 1024;
+
+      this.logger?.debug(
+        `Requested 'estimatesmartfee'. Response: ${JsonBigInt.stringify(
+          response.data.result,
+        )}`,
+      );
+      return Math.ceil(feeRate);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get fee ratio from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * checks if a transaction is in the mempool
+   * @param txId the transaction id
+   * @returns true if the transaction is in the mempool
+   */
+  isTxInMempool = async (txId: string): Promise<boolean> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getmempoolentry',
+        id: randomId,
+        params: [txId],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      // If we get a successful response, the transaction is in the mempool
+      return true;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      // If we get a specific error indicating the tx is not in the mempool
+      if (e.response && e.response.data && e.response.data.error) {
+        if (e.response.data.error.code === -5) {
+          // Transaction not in mempool
+          return false;
+        }
+      }
+
+      const baseError = `Failed to check if tx [${txId}] is in mempool from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets transaction hex
+   * @param txId the transaction id
+   * @returns the transaction hex
+   */
+  getTransactionHex = async (txId: string): Promise<string> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getrawtransaction',
+        id: randomId,
+        params: [txId, false], // txid, verbose (false = return hex)
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const txHex: string = response.data.result;
+      this.logger?.debug(`Requested transaction hex for txId [${txId}].`);
+
+      return txHex;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get transaction hex [${txId}] from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets confirmed and unspent UTXOs of an address
+   * @param address the address
+   * @param offset offset for pagination
+   * @param limit maximum number of UTXOs to return
+   * @returns list of UTXOs
+   */
+  getAddressBoxes = async (
+    address: string,
+    offset: number,
+    limit: number,
+  ): Promise<Array<FiroUtxo>> => {
+    const randomId = this.generateRandomId();
+    try {
+      // Get list of unspent outputs for the address
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'listunspent',
+        id: randomId,
+        params: [1, 9999999, [address]], // minconf, maxconf, addresses
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const utxos: Array<{
+        txid: string;
+        vout: number;
+        address: string;
+        scriptPubKey: string;
+        amount: number;
+        confirmations: number;
+      }> = response.data.result;
+
+      // Convert to FiroUtxo format and apply pagination
+      const firoUtxos = utxos.slice(offset, offset + limit).map((utxo) => ({
+        txId: utxo.txid,
+        index: utxo.vout,
+        value: this.convertToSatoshis(utxo.amount),
+      }));
+
+      this.logger?.debug(
+        `Requested 'listunspent' for address [${address}]. Found ${utxos.length} UTXOs, returning ${firoUtxos.length}.`,
+      );
+
+      return firoUtxos;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get address boxes for [${address}] from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets the number of confirmations for a transaction
+   * @param transactionId the transaction id
+   * @returns the number of confirmations
+   */
+  getTxConfirmation = async (transactionId: string): Promise<number> => {
+    const randomId = this.generateRandomId();
+    try {
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'getrawtransaction',
+        id: randomId,
+        params: [transactionId, true],
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const tx: FiroRpcTransaction = response.data.result;
+
+      return tx.confirmations || 0;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get transaction confirmations for [${transactionId}] from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets the balance of native assets for an address
+   * @param address the address
+   * @returns the asset balance (only native token, Firo doesn't support tokens)
+   */
+  getAddressAssets = async (
+    address: string,
+  ): Promise<{
+    nativeToken: bigint;
+    tokens: Array<{ id: string; value: bigint }>;
+  }> => {
+    const randomId = this.generateRandomId();
+    try {
+      // Get list of unspent outputs for the address
+      const response = await this.client.post<JsonRpcResult>('', {
+        method: 'listunspent',
+        id: randomId,
+        params: [0, 9999999, [address]], // minconf=0 to include mempool
+      });
+
+      this.validateResponseId(randomId, response.data.id);
+
+      const utxos: Array<{ amount: number }> = response.data.result;
+
+      // Sum up all UTXO values
+      const totalSatoshis = utxos.reduce(
+        (sum, utxo) => sum + this.convertToSatoshis(utxo.amount),
+        0n,
+      );
+
+      this.logger?.debug(
+        `Requested address assets for [${address}]. Total: ${totalSatoshis} satoshis.`,
+      );
+
+      return {
+        nativeToken: totalSatoshis,
+        tokens: [], // Firo doesn't support tokens
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (e: any) {
+      const baseError = `Failed to get address assets for [${address}] from Firo RPC: `;
+      if (e.response) {
+        throw new FailedError(
+          baseError + JsonBigInt.stringify(e.response.data),
+        );
+      } else if (e.request) {
+        throw new NetworkError(baseError + e.message);
+      } else {
+        throw new UnexpectedApiError(baseError + e.message);
+      }
+    }
+  };
+
+  /**
+   * gets the actual transaction ID from a transaction hash
+   * For Firo (like Bitcoin), the transaction ID and hash are the same
+   * @param hash the transaction hash
+   * @returns the actual transaction ID
+   */
+  getActualTxId = async (hash: string): Promise<string> => {
+    return hash;
+  };
+}
+
+export default FiroRpcNetwork;

--- a/packages/networks/firo-rpc/lib/index.ts
+++ b/packages/networks/firo-rpc/lib/index.ts
@@ -1,0 +1,4 @@
+import FiroRpcNetwork from './firoRpcNetwork';
+import { RpcAuth } from './types';
+
+export { FiroRpcNetwork, RpcAuth };

--- a/packages/networks/firo-rpc/lib/types.ts
+++ b/packages/networks/firo-rpc/lib/types.ts
@@ -1,0 +1,105 @@
+export interface FiroBlockSummary {
+  hash: string;
+  height: number;
+  time: number;
+  previousblockhash: string;
+  tx: Array<string>;
+  confirmations: number;
+  difficulty: number;
+  merkleroot: string;
+  nonce: number;
+  size: number;
+  weight: number;
+  version: number;
+  versionHex: string;
+  chainwork: string;
+  bits: string;
+  mediantime: number;
+  nextblockhash?: string;
+}
+
+export interface FiroRpcTxInput {
+  txid?: string; // Not present in coinbase transactions
+  vout?: number; // Not present in coinbase transactions
+  scriptSig?: {
+    // Not present in coinbase transactions
+    asm: string;
+    hex: string;
+  };
+  sequence: number;
+  coinbase?: string; // Only present in coinbase transactions
+  txinwitness?: string[];
+}
+
+export interface FiroRpcTxOutput {
+  value: number;
+  n: number;
+  scriptPubKey: {
+    asm: string;
+    hex: string;
+    type: string;
+    addresses?: string[];
+    reqSigs?: number;
+  };
+}
+
+export interface FiroRpcTransaction {
+  txid: string;
+  hash: string;
+  version: number;
+  size: number;
+  vsize: number;
+  weight: number;
+  locktime: number;
+  vin: Array<FiroRpcTxInput>;
+  vout: Array<FiroRpcTxOutput>;
+  hex?: string;
+  blockhash?: string;
+  confirmations?: number;
+  time?: number;
+  blocktime?: number;
+  blockheight?: number;
+}
+
+export interface JsonRpcResult {
+  result: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  error: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  id: string;
+}
+
+export interface FiroChainInfo {
+  chain: string;
+  blocks: number;
+  headers: number;
+  bestblockhash: string;
+  difficulty: number;
+  mediantime: number;
+  verificationprogress: number;
+  initialblockdownload: boolean;
+  chainwork: string;
+  size_on_disk: number;
+  pruned: boolean;
+  softforks: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  warnings: string;
+}
+
+export interface FiroUtxo {
+  txid: string;
+  vout: number;
+  address: string;
+  scriptPubKey: string;
+  amount: number;
+  confirmations: number;
+  spendable: boolean;
+  solvable: boolean;
+  safe: boolean;
+}
+
+/**
+ * Authentication credentials for Firocoin RPC
+ */
+export interface RpcAuth {
+  username?: string;
+  password?: string;
+  apiKey?: string;
+}

--- a/packages/networks/firo-rpc/lib/types.ts
+++ b/packages/networks/firo-rpc/lib/types.ts
@@ -95,6 +95,15 @@ export interface FiroUtxo {
   safe: boolean;
 }
 
+export interface FiroRpcUtxo {
+  txid: string;
+  vout: number;
+  address: string;
+  scriptPubKey: string;
+  amount: number;
+  confirmations: number;
+}
+
 /**
  * Authentication credentials for Firocoin RPC
  */

--- a/packages/networks/firo-rpc/package.json
+++ b/packages/networks/firo-rpc/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/networks/firo-rpc"
   },
   "license": "MIT",
-  "author": "Rosen Team",
+  "author": "Navid Rahimi",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -34,15 +34,10 @@
   "dependencies": {
     "@rosen-bridge/abstract-logger": "^4.0.0",
     "@rosen-bridge/json-bigint": "^1.1.0",
-    "@rosen-chains/abstract-chain": "^15.0.1",
+    "@rosen-chains/abstract-chain": "^15.0.2",
     "@rosen-chains/firo": "^0.0.0",
-    "@rosen-clients/rate-limited-axios": "^1.1.0",
+    "@rosen-clients/rate-limited-axios": "^1.1.1",
     "bitcoinjs-lib": "^6.1.5"
-  },
-  "devDependencies": {
-    "@vitest/coverage-istanbul": "^3.1.4",
-    "tsx": "^4.20.5",
-    "vitest": "^3.1.4"
   },
   "engines": {
     "node": ">=22.18.0",

--- a/packages/networks/firo-rpc/package.json
+++ b/packages/networks/firo-rpc/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@rosen-chains/firo-rpc",
+  "version": "0.0.0",
+  "description": "A package to be used as network api provider for @rosen-chains/firo package using RPC API",
+  "keywords": [
+    "rosen"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rosen-bridge/rosen-chains.git",
+    "directory": "packages/networks/firo-rpc"
+  },
+  "license": "MIT",
+  "author": "Rosen Team",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "rimraf dist && rimraf tsconfig.build.tsbuildinfo",
+    "coverage": "npm run test -- --run --coverage",
+    "lint": "eslint --fix . && npm run prettify",
+    "lint:check": "eslint . && npm run prettify:check",
+    "prettify": "prettier --write . --ignore-path ../../../.gitignore",
+    "prettify:check": "prettier --check . --ignore-path ../../../.gitignore",
+    "release": "npm run test -- --run && npm run clean && npm run build && npm publish --access public",
+    "test": "NODE_OPTIONS='--import tsx' vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@rosen-bridge/abstract-logger": "^4.0.0",
+    "@rosen-bridge/json-bigint": "^1.1.0",
+    "@rosen-chains/abstract-chain": "^15.0.1",
+    "@rosen-chains/firo": "^0.0.0",
+    "@rosen-clients/rate-limited-axios": "^1.1.0",
+    "bitcoinjs-lib": "^6.1.5"
+  },
+  "devDependencies": {
+    "@vitest/coverage-istanbul": "^3.1.4",
+    "tsx": "^4.20.5",
+    "vitest": "^3.1.4"
+  },
+  "engines": {
+    "node": ">=22.18.0",
+    "npm": "11.6.2"
+  }
+}

--- a/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
+++ b/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
@@ -6,25 +6,13 @@ import FiroRpcNetwork from '../lib/firoRpcNetwork';
 import { resetAxiosMock, axiosInstance } from './mocked/rateLimitedAxios.mock';
 import * as testData from './testData';
 
+const mockGetSavedTransactionById = vi.fn().mockReturnValue(undefined);
+
 describe('FiroRpcNetwork', () => {
   const URL = 'firo-rpc-url';
 
   beforeEach(() => {
     resetAxiosMock();
-  });
-
-  /**
-   * @target `FiroRpcNetwork` should be instantiable
-   * @dependencies
-   * @scenario
-   * - Create instance of FiroRpcNetwork
-   * @expected
-   * - Instance should be created successfully
-   */
-  it('should create an instance of FiroRpcNetwork', () => {
-    const network = new FiroRpcNetwork(URL);
-    expect(network).toBeDefined();
-    expect(network).toBeInstanceOf(FiroRpcNetwork);
   });
 
   describe('getHeight', () => {
@@ -50,7 +38,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getHeight();
 
       expect(result).toEqual(testData.blockHeightResponse.result.blocks);
@@ -74,7 +62,7 @@ describe('FiroRpcNetwork', () => {
         },
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       await expect(network.getHeight()).rejects.toThrow(FailedError);
     });
 
@@ -93,7 +81,7 @@ describe('FiroRpcNetwork', () => {
         message: 'Network error',
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       await expect(network.getHeight()).rejects.toThrow(NetworkError);
     });
   });
@@ -120,7 +108,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getBlockTransactionIds(testData.blockHash);
 
       expect(result).toEqual(testData.blockResponse.result.tx);
@@ -149,7 +137,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getBlockInfo(testData.blockHash);
 
       expect(result).toEqual(testData.blockInfo);
@@ -178,7 +166,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getTransaction(
         testData.txId,
         testData.txBlockHash,
@@ -210,7 +198,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.isBoxUnspentAndValid(`${testData.txId}.0`);
 
       expect(result).toEqual(true);
@@ -237,7 +225,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.isBoxUnspentAndValid(`${testData.txId}.0`);
 
       expect(result).toEqual(false);
@@ -265,7 +253,7 @@ describe('FiroRpcNetwork', () => {
         },
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.isBoxUnspentAndValid(`${testData.txId}.0`);
 
       expect(result).toEqual(false);
@@ -306,7 +294,7 @@ describe('FiroRpcNetwork', () => {
         return Promise.reject(new Error(`Unexpected method: ${method}`));
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getUtxo(`${testData.txId}.0`);
 
       expect(result.txId).toEqual(testData.txId);
@@ -337,7 +325,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getFeeRatio();
 
       // Convert FIRO/kB to satoshis/byte
@@ -371,7 +359,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.isTxInMempool(testData.txId);
 
       expect(result).toEqual(true);
@@ -396,7 +384,7 @@ describe('FiroRpcNetwork', () => {
         },
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.isTxInMempool(testData.txId);
 
       expect(result).toEqual(false);
@@ -425,7 +413,7 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getTransactionHex(testData.txId);
 
       expect(result).toEqual(testData.txHexResponse.result);
@@ -463,7 +451,7 @@ describe('FiroRpcNetwork', () => {
         }),
       };
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       // This should not throw an error
       await expect(
         network.submitTransaction(mockPsbt as any), // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -473,7 +461,7 @@ describe('FiroRpcNetwork', () => {
 
   describe('getAddressBoxes', () => {
     /**
-     * @target `FiroRpcNetwork.getAddressBoxes` should return address UTXOs successfully
+     * @target `FiroRpcNetwork.getAddressBoxes` should return address UTXOs successfully with pagination
      * @dependencies
      * @scenario
      * - mock axios to return listunspent data
@@ -483,55 +471,22 @@ describe('FiroRpcNetwork', () => {
      * - it should return paginated UTXOs in correct format
      */
     it('should return address UTXOs successfully with pagination', async () => {
-      const mockUtxos = [
-        {
-          txid: testData.txId,
-          vout: 0,
-          address: testData.lockAddress,
-          scriptPubKey: testData.lockAddressPublicKey,
-          amount: 10.5,
-          confirmations: 10,
-        },
-        {
-          txid: '2nd-tx-id',
-          vout: 1,
-          address: testData.lockAddress,
-          scriptPubKey: testData.lockAddressPublicKey,
-          amount: 5.25,
-          confirmations: 5,
-        },
-        {
-          txid: '3rd-tx-id',
-          vout: 0,
-          address: testData.lockAddress,
-          scriptPubKey: testData.lockAddressPublicKey,
-          amount: 2.0,
-          confirmations: 3,
-        },
-      ];
-
       axiosInstance.post.mockImplementation((url, data) => {
         const { id } = data;
         return Promise.resolve({
           data: {
-            result: mockUtxos,
+            result: testData.mockAddressUtxos,
             error: null,
             id: id,
           },
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       // Get first 2 UTXOs (offset 0, limit 2)
       const result = await network.getAddressBoxes(testData.lockAddress, 0, 2);
 
-      expect(result).toHaveLength(2);
-      expect(result[0].txId).toEqual(testData.txId);
-      expect(result[0].index).toEqual(0);
-      expect(result[0].value).toEqual(1050000000n); // 10.5 FIRO in satoshis
-      expect(result[1].txId).toEqual('2nd-tx-id');
-      expect(result[1].index).toEqual(1);
-      expect(result[1].value).toEqual(525000000n); // 5.25 FIRO in satoshis
+      expect(result).toEqual(testData.expectedAddressBoxes);
     });
 
     /**
@@ -556,37 +511,10 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getAddressBoxes('empty-address', 0, 10);
 
       expect(result).toEqual([]);
-    });
-
-    /**
-     * @target `FiroRpcNetwork.getAddressBoxes` should throw FailedError on API error
-     * @dependencies
-     * @scenario
-     * - mock axios to return error
-     * - run test
-     * @expected
-     * - it should throw FailedError
-     */
-    it('should throw FailedError on API error', async () => {
-      axiosInstance.post.mockRejectedValueOnce({
-        response: {
-          data: {
-            error: {
-              code: -5,
-              message: 'Invalid address',
-            },
-          },
-        },
-      });
-
-      const network = new FiroRpcNetwork(URL);
-      await expect(
-        network.getAddressBoxes('invalid-address', 0, 10),
-      ).rejects.toThrow(FailedError);
     });
   });
 
@@ -612,23 +540,23 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getTxConfirmation(testData.txId);
 
-      expect(result).toEqual(testData.txResponse.result.confirmations);
+      expect(result).toEqual(testData.expectedTxConfirmation);
     });
 
     /**
-     * @target `FiroRpcNetwork.getTxConfirmation` should return 0 for unconfirmed tx
+     * @target `FiroRpcNetwork.getTxConfirmation` should return -1 for unconfirmed tx
      * @dependencies
      * @scenario
      * - mock axios to return transaction without confirmations field
      * - run test
      * - check returned value
      * @expected
-     * - it should return 0
+     * - it should return -1
      */
-    it('should return 0 for unconfirmed transaction', async () => {
+    it('should return -1 for unconfirmed transaction', async () => {
       const unconfirmedTxResponse = {
         result: {
           ...testData.txResponse.result,
@@ -648,37 +576,10 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getTxConfirmation(testData.txId);
 
-      expect(result).toEqual(0);
-    });
-
-    /**
-     * @target `FiroRpcNetwork.getTxConfirmation` should throw FailedError when tx not found
-     * @dependencies
-     * @scenario
-     * - mock axios to return error for non-existent tx
-     * - run test
-     * @expected
-     * - it should throw FailedError
-     */
-    it('should throw FailedError when transaction not found', async () => {
-      axiosInstance.post.mockRejectedValueOnce({
-        response: {
-          data: {
-            error: {
-              code: -5,
-              message: 'No such transaction',
-            },
-          },
-        },
-      });
-
-      const network = new FiroRpcNetwork(URL);
-      await expect(network.getTxConfirmation('invalid-tx-id')).rejects.toThrow(
-        FailedError,
-      );
+      expect(result).toEqual(-1);
     });
   });
 
@@ -694,24 +595,21 @@ describe('FiroRpcNetwork', () => {
      * - it should return sum of all UTXOs as native token balance
      */
     it('should return address balance successfully', async () => {
-      const mockUtxos = [{ amount: 10.5 }, { amount: 5.25 }, { amount: 2.0 }];
-
       axiosInstance.post.mockImplementation((url, data) => {
         const { id } = data;
         return Promise.resolve({
           data: {
-            result: mockUtxos,
+            result: testData.mockAddressUtxos,
             error: null,
             id: id,
           },
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getAddressAssets(testData.lockAddress);
 
-      // Total: 17.75 FIRO = 1775000000 satoshis
-      expect(result.nativeToken).toEqual(1775000000n);
+      expect(result.nativeToken).toEqual(testData.expectedAddressBalance);
       expect(result.tokens).toEqual([]); // Firo doesn't support tokens
       expect(axiosInstance.post).toHaveBeenCalledWith(
         '',
@@ -744,91 +642,167 @@ describe('FiroRpcNetwork', () => {
         });
       });
 
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const result = await network.getAddressAssets('empty-address');
 
       expect(result.nativeToken).toEqual(0n);
       expect(result.tokens).toEqual([]);
     });
-
-    /**
-     * @target `FiroRpcNetwork.getAddressAssets` should include mempool transactions (minconf=0)
-     * @dependencies
-     * @scenario
-     * - verify that the RPC call uses minconf=0 to include unconfirmed txs
-     * - mock axios and check call parameters
-     * - run test
-     * @expected
-     * - it should call listunspent with minconf=0
-     */
-    it('should include mempool transactions', async () => {
-      axiosInstance.post.mockImplementation((url, data) => {
-        const { method, params, id } = data;
-
-        // Verify the call is made with minconf=0
-        if (method === 'listunspent') {
-          expect(params[0]).toEqual(0); // minconf should be 0
-        }
-
-        return Promise.resolve({
-          data: {
-            result: [{ amount: 1.0 }],
-            error: null,
-            id: id,
-          },
-        });
-      });
-
-      const network = new FiroRpcNetwork(URL);
-      await network.getAddressAssets(testData.lockAddress);
-
-      expect(axiosInstance.post).toHaveBeenCalled();
-    });
-
-    /**
-     * @target `FiroRpcNetwork.getAddressAssets` should throw FailedError on API error
-     * @dependencies
-     * @scenario
-     * - mock axios to return error
-     * - run test
-     * @expected
-     * - it should throw FailedError
-     */
-    it('should throw FailedError on API error', async () => {
-      axiosInstance.post.mockRejectedValueOnce({
-        response: {
-          data: {
-            error: {
-              code: -5,
-              message: 'Invalid address',
-            },
-          },
-        },
-      });
-
-      const network = new FiroRpcNetwork(URL);
-      await expect(network.getAddressAssets('invalid-address')).rejects.toThrow(
-        FailedError,
-      );
-    });
   });
 
   describe('getActualTxId', () => {
     /**
-     * @target `FiroRpcNetwork.getActualTxId` should return the same hash
+     * @target `FiroRpcNetwork.getActualTxId` should return the same hash when no saved transaction exists
      * @dependencies
      * @scenario
      * - call getActualTxId with a transaction hash
      * - check returned value
      * @expected
-     * - it should return the same hash (identity function for Bitcoin-like chains)
+     * - it should return the same hash when transaction is not in database
      */
-    it('should return the same hash (identity function)', async () => {
-      const network = new FiroRpcNetwork(URL);
+    it('should return the same hash when no saved transaction exists', async () => {
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const hash = testData.txId;
       const result = await network.getActualTxId(hash);
 
       expect(result).toEqual(hash);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getActualTxId` should extract signed txId from PSBT (method 1)
+     * @dependencies
+     * @scenario
+     * - create a custom getSavedTransactionById that returns a payment transaction
+     * - mock the direct PSBT extraction to succeed
+     * - call getActualTxId with the unsigned hash
+     * @expected
+     * - it should use the direct extraction method and return signed ID
+     */
+    it('should extract signed txId from PSBT using direct method', async () => {
+      const { PaymentTransaction, TransactionType } = await import(
+        '@rosen-chains/abstract-chain'
+      );
+
+      const firoPayment = new PaymentTransaction(
+        'firo',
+        testData.unsignedTxId,
+        'eventId',
+        Buffer.from(testData.firoPaymentBytes, 'hex'),
+        TransactionType.payment,
+      );
+
+      const customNetwork = new FiroRpcNetwork(URL, async (txId: string) => {
+        if (txId === testData.unsignedTxId) {
+          return firoPayment;
+        }
+        return undefined;
+      });
+
+      // Mock the direct extraction method to succeed
+      const extractDirectSpy = vi
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(customNetwork as any, 'extractActualTxIdFromPsbt')
+        .mockResolvedValue(testData.txId);
+
+      const result = await customNetwork.getActualTxId(testData.unsignedTxId);
+
+      expect(extractDirectSpy).toHaveBeenCalled();
+      expect(result).toEqual(testData.txId);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getActualTxId` should fallback to RPC lookup when direct extraction fails
+     * @dependencies
+     * @scenario
+     * - create a custom getSavedTransactionById that returns a payment transaction
+     * - mock direct extraction to fail
+     * - mock RPC lookup to succeed
+     * @expected
+     * - it should fallback to RPC lookup method and return signed ID
+     */
+    it('should fallback to RPC lookup when direct extraction fails', async () => {
+      const { PaymentTransaction, TransactionType } = await import(
+        '@rosen-chains/abstract-chain'
+      );
+
+      const firoPayment = new PaymentTransaction(
+        'firo',
+        testData.unsignedTxId,
+        'eventId',
+        Buffer.from(testData.firoPaymentBytes, 'hex'),
+        TransactionType.payment,
+      );
+
+      const customNetwork = new FiroRpcNetwork(URL, async (txId: string) => {
+        if (txId === testData.unsignedTxId) {
+          return firoPayment;
+        }
+        return undefined;
+      });
+
+      // Mock direct extraction to fail
+      const extractDirectSpy = vi
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(customNetwork as any, 'extractActualTxIdFromPsbt')
+        .mockResolvedValue(undefined);
+
+      // Mock RPC lookup to succeed
+      const extractRpcSpy = vi
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn(customNetwork as any, 'extractActualTxIdWithRpcLookup')
+        .mockResolvedValue(testData.txId);
+
+      const result = await customNetwork.getActualTxId(testData.unsignedTxId);
+
+      expect(extractDirectSpy).toHaveBeenCalled();
+      expect(extractRpcSpy).toHaveBeenCalled();
+      expect(result).toEqual(testData.txId);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getActualTxId` should return original hash when both methods fail
+     * @dependencies
+     * @scenario
+     * - create a custom getSavedTransactionById that returns a payment transaction
+     * - mock both extraction methods to fail
+     * @expected
+     * - it should return the original hash as fallback
+     */
+    it('should return original hash when both extraction methods fail', async () => {
+      const { PaymentTransaction, TransactionType } = await import(
+        '@rosen-chains/abstract-chain'
+      );
+
+      const firoPayment = new PaymentTransaction(
+        'firo',
+        testData.unsignedTxId,
+        'eventId',
+        Buffer.from(testData.firoPaymentBytes, 'hex'),
+        TransactionType.payment,
+      );
+
+      const customNetwork = new FiroRpcNetwork(URL, async (txId: string) => {
+        if (txId === testData.unsignedTxId) {
+          return firoPayment;
+        }
+        return undefined;
+      });
+
+      // Mock both methods to fail
+      vi.spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        customNetwork as any,
+        'extractActualTxIdFromPsbt',
+      ).mockResolvedValue(undefined);
+      vi.spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        customNetwork as any,
+        'extractActualTxIdWithRpcLookup',
+      ).mockResolvedValue(undefined);
+
+      const result = await customNetwork.getActualTxId(testData.unsignedTxId);
+
+      expect(result).toEqual(testData.unsignedTxId);
     });
 
     /**
@@ -838,10 +812,10 @@ describe('FiroRpcNetwork', () => {
      * - call getActualTxId with various hash formats
      * - check returned values
      * @expected
-     * - it should always return the input unchanged
+     * - it should return the input unchanged when not in database
      */
     it('should work with any hash string', async () => {
-      const network = new FiroRpcNetwork(URL);
+      const network = new FiroRpcNetwork(URL, mockGetSavedTransactionById);
       const testHashes = [
         'abc123',
         '0000000000000000000000000000000000000000000000000000000000000000',

--- a/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
+++ b/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
@@ -1,0 +1,850 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+import { FailedError, NetworkError } from '@rosen-chains/abstract-chain';
+
+import FiroRpcNetwork from '../lib/firoRpcNetwork';
+import { resetAxiosMock, axiosInstance } from './mocked/rateLimitedAxios.mock';
+import * as testData from './testData';
+
+describe('FiroRpcNetwork', () => {
+  const URL = 'firo-rpc-url';
+
+  beforeEach(() => {
+    resetAxiosMock();
+  });
+
+  /**
+   * @target `FiroRpcNetwork` should be instantiable
+   * @dependencies
+   * @scenario
+   * - Create instance of FiroRpcNetwork
+   * @expected
+   * - Instance should be created successfully
+   */
+  it('should create an instance of FiroRpcNetwork', () => {
+    const network = new FiroRpcNetwork(URL);
+    expect(network).toBeDefined();
+    expect(network).toBeInstanceOf(FiroRpcNetwork);
+  });
+
+  describe('getHeight', () => {
+    /**
+     * @target `FiroRpcNetwork.getHeight` should return block height successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return blockchain info
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should be mocked block height
+     */
+    it('should return block height successfully', async () => {
+      // Set up the mock for this specific test
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.blockHeightResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getHeight();
+
+      expect(result).toEqual(testData.blockHeightResponse.result.blocks);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getHeight` should throw FailedError when API returns error
+     * @dependencies
+     * @scenario
+     * - mock axios to return error response
+     * - run test
+     * @expected
+     * - it should throw FailedError
+     */
+    it('should throw FailedError when API returns error', async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        response: {
+          data: {
+            error: 'Server error',
+          },
+        },
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      await expect(network.getHeight()).rejects.toThrow(FailedError);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getHeight` should throw NetworkError when network error occurs
+     * @dependencies
+     * @scenario
+     * - mock axios to throw network error
+     * - run test
+     * @expected
+     * - it should throw NetworkError
+     */
+    it('should throw NetworkError when network error occurs', async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        request: {},
+        message: 'Network error',
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      await expect(network.getHeight()).rejects.toThrow(NetworkError);
+    });
+  });
+
+  describe('getBlockTransactionIds', () => {
+    /**
+     * @target `FiroRpcNetwork.getBlockTransactionIds` should return block tx ids successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return block data
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should be mocked tx ids
+     */
+    it('should return block tx ids successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.blockResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getBlockTransactionIds(testData.blockHash);
+
+      expect(result).toEqual(testData.blockResponse.result.tx);
+    });
+  });
+
+  describe('getBlockInfo', () => {
+    /**
+     * @target `FiroRpcNetwork.getBlockInfo` should return block info successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return block data
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should match mocked block info
+     */
+    it('should return block info successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.blockResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getBlockInfo(testData.blockHash);
+
+      expect(result).toEqual(testData.blockInfo);
+    });
+  });
+
+  describe('getTransaction', () => {
+    /**
+     * @target `FiroRpcNetwork.getTransaction` should return transaction successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return transaction data
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should match expected transaction format
+     */
+    it('should return transaction successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.txResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getTransaction(
+        testData.txId,
+        testData.txBlockHash,
+      );
+
+      expect(result).toEqual(testData.firoTx);
+    });
+  });
+
+  describe('isBoxUnspentAndValid', () => {
+    /**
+     * @target `FiroRpcNetwork.isBoxUnspentAndValid` should return true for unspent output
+     * @dependencies
+     * @scenario
+     * - mock axios to return UTXO data
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return true
+     */
+    it('should return true for unspent output', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.txOutResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.isBoxUnspentAndValid(`${testData.txId}.0`);
+
+      expect(result).toEqual(true);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.isBoxUnspentAndValid` should return false for spent output
+     * @dependencies
+     * @scenario
+     * - mock axios to return null for spent output
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return false
+     */
+    it('should return false for spent output', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        return Promise.resolve({
+          data: {
+            result: null,
+            error: null,
+            id: data.id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.isBoxUnspentAndValid(`${testData.txId}.0`);
+
+      expect(result).toEqual(false);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.isBoxUnspentAndValid` should return false when transaction doesn't exist
+     * @dependencies
+     * @scenario
+     * - mock axios to throw error with code -5 (no such transaction)
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return false
+     */
+    it("should return false when transaction doesn't exist", async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        response: {
+          data: {
+            error: {
+              code: -5,
+              message: 'No such transaction',
+            },
+          },
+        },
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.isBoxUnspentAndValid(`${testData.txId}.0`);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('getUtxo', () => {
+    /**
+     * @target `FiroRpcNetwork.getUtxo` should return UTXO data successfully
+     * @dependencies
+     * @scenario
+     * - mock axios for transaction and UTXO check
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should match expected UTXO format
+     */
+    it('should return UTXO data successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { method, id } = data;
+
+        if (method === 'getrawtransaction') {
+          return Promise.resolve({
+            data: {
+              ...testData.txResponse,
+              id: id,
+            },
+          });
+        } else if (method === 'gettxout') {
+          return Promise.resolve({
+            data: {
+              ...testData.txOutResponse,
+              id: id,
+            },
+          });
+        }
+
+        return Promise.reject(new Error(`Unexpected method: ${method}`));
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getUtxo(`${testData.txId}.0`);
+
+      expect(result.txId).toEqual(testData.txId);
+      expect(result.index).toEqual(0);
+      expect(result.value).toEqual(testData.firoUtxo.value);
+    });
+  });
+
+  describe('getFeeRatio', () => {
+    /**
+     * @target `FiroRpcNetwork.getFeeRatio` should return fee ratio successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return fee estimation
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return calculated fee ratio (satoshis/byte)
+     */
+    it('should return fee ratio successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.estimateSmartFeeResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getFeeRatio();
+
+      // Convert FIRO/kB to satoshis/byte
+      const expectedFeeRate = Math.ceil(
+        (testData.estimateSmartFeeResponse.result.feerate * 100000000) / 1024,
+      );
+      expect(result).toEqual(expectedFeeRate);
+    });
+  });
+
+  describe('isTxInMempool', () => {
+    /**
+     * @target `FiroRpcNetwork.isTxInMempool` should return true when tx is in mempool
+     * @dependencies
+     * @scenario
+     * - mock axios to return success for mempool query
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return true
+     */
+    it('should return true when tx is in mempool', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            result: { fees: 0.1 },
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.isTxInMempool(testData.txId);
+
+      expect(result).toEqual(true);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.isTxInMempool` should return false when tx is not in mempool
+     * @dependencies
+     * @scenario
+     * - mock axios to return error for tx not in mempool
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return false
+     */
+    it('should return false when tx is not in mempool', async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        response: {
+          data: {
+            ...testData.txNotInMempoolResponse,
+          },
+        },
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.isTxInMempool(testData.txId);
+
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe('getTransactionHex', () => {
+    /**
+     * @target `FiroRpcNetwork.getTransactionHex` should return transaction hex successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return transaction hex
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should match expected transaction hex
+     */
+    it('should return transaction hex successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.txHexResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getTransactionHex(testData.txId);
+
+      expect(result).toEqual(testData.txHexResponse.result);
+    });
+  });
+
+  describe('submitTransaction', () => {
+    /**
+     * @target `FiroRpcNetwork.submitTransaction` should submit transaction successfully
+     * @dependencies
+     * @scenario
+     * - mock Psbt for transaction extraction
+     * - mock axios response for submission
+     * - run test
+     * @expected
+     * - it should not throw error
+     */
+    it('should submit transaction successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            result: testData.txId,
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      // Create a mock PSBT
+      const mockPsbt = {
+        finalizeAllInputs: vi.fn(),
+        extractTransaction: vi.fn().mockReturnValue({
+          toHex: vi.fn().mockReturnValue('01000000...'),
+        }),
+      };
+
+      const network = new FiroRpcNetwork(URL);
+      // This should not throw an error
+      await expect(
+        network.submitTransaction(mockPsbt as any), // eslint-disable-line @typescript-eslint/no-explicit-any
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('getAddressBoxes', () => {
+    /**
+     * @target `FiroRpcNetwork.getAddressBoxes` should return address UTXOs successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return listunspent data
+     * - run test with pagination parameters
+     * - check returned value
+     * @expected
+     * - it should return paginated UTXOs in correct format
+     */
+    it('should return address UTXOs successfully with pagination', async () => {
+      const mockUtxos = [
+        {
+          txid: testData.txId,
+          vout: 0,
+          address: testData.lockAddress,
+          scriptPubKey: testData.lockAddressPublicKey,
+          amount: 10.5,
+          confirmations: 10,
+        },
+        {
+          txid: '2nd-tx-id',
+          vout: 1,
+          address: testData.lockAddress,
+          scriptPubKey: testData.lockAddressPublicKey,
+          amount: 5.25,
+          confirmations: 5,
+        },
+        {
+          txid: '3rd-tx-id',
+          vout: 0,
+          address: testData.lockAddress,
+          scriptPubKey: testData.lockAddressPublicKey,
+          amount: 2.0,
+          confirmations: 3,
+        },
+      ];
+
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            result: mockUtxos,
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      // Get first 2 UTXOs (offset 0, limit 2)
+      const result = await network.getAddressBoxes(testData.lockAddress, 0, 2);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].txId).toEqual(testData.txId);
+      expect(result[0].index).toEqual(0);
+      expect(result[0].value).toEqual(1050000000n); // 10.5 FIRO in satoshis
+      expect(result[1].txId).toEqual('2nd-tx-id');
+      expect(result[1].index).toEqual(1);
+      expect(result[1].value).toEqual(525000000n); // 5.25 FIRO in satoshis
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getAddressBoxes` should handle empty address
+     * @dependencies
+     * @scenario
+     * - mock axios to return empty UTXO list
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return empty array
+     */
+    it('should handle empty address', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            result: [],
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getAddressBoxes('empty-address', 0, 10);
+
+      expect(result).toEqual([]);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getAddressBoxes` should throw FailedError on API error
+     * @dependencies
+     * @scenario
+     * - mock axios to return error
+     * - run test
+     * @expected
+     * - it should throw FailedError
+     */
+    it('should throw FailedError on API error', async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        response: {
+          data: {
+            error: {
+              code: -5,
+              message: 'Invalid address',
+            },
+          },
+        },
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      await expect(
+        network.getAddressBoxes('invalid-address', 0, 10),
+      ).rejects.toThrow(FailedError);
+    });
+  });
+
+  describe('getTxConfirmation', () => {
+    /**
+     * @target `FiroRpcNetwork.getTxConfirmation` should return confirmation count successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return transaction with confirmations
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return correct number of confirmations
+     */
+    it('should return confirmation count successfully', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...testData.txResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getTxConfirmation(testData.txId);
+
+      expect(result).toEqual(testData.txResponse.result.confirmations);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getTxConfirmation` should return 0 for unconfirmed tx
+     * @dependencies
+     * @scenario
+     * - mock axios to return transaction without confirmations field
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return 0
+     */
+    it('should return 0 for unconfirmed transaction', async () => {
+      const unconfirmedTxResponse = {
+        result: {
+          ...testData.txResponse.result,
+          confirmations: undefined,
+        },
+        error: null,
+        id: 'tx_request',
+      };
+
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            ...unconfirmedTxResponse,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getTxConfirmation(testData.txId);
+
+      expect(result).toEqual(0);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getTxConfirmation` should throw FailedError when tx not found
+     * @dependencies
+     * @scenario
+     * - mock axios to return error for non-existent tx
+     * - run test
+     * @expected
+     * - it should throw FailedError
+     */
+    it('should throw FailedError when transaction not found', async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        response: {
+          data: {
+            error: {
+              code: -5,
+              message: 'No such transaction',
+            },
+          },
+        },
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      await expect(network.getTxConfirmation('invalid-tx-id')).rejects.toThrow(
+        FailedError,
+      );
+    });
+  });
+
+  describe('getAddressAssets', () => {
+    /**
+     * @target `FiroRpcNetwork.getAddressAssets` should return address balance successfully
+     * @dependencies
+     * @scenario
+     * - mock axios to return listunspent with multiple UTXOs
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return sum of all UTXOs as native token balance
+     */
+    it('should return address balance successfully', async () => {
+      const mockUtxos = [{ amount: 10.5 }, { amount: 5.25 }, { amount: 2.0 }];
+
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            result: mockUtxos,
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getAddressAssets(testData.lockAddress);
+
+      // Total: 17.75 FIRO = 1775000000 satoshis
+      expect(result.nativeToken).toEqual(1775000000n);
+      expect(result.tokens).toEqual([]); // Firo doesn't support tokens
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getAddressAssets` should return 0 for empty address
+     * @dependencies
+     * @scenario
+     * - mock axios to return empty UTXO list
+     * - run test
+     * - check returned value
+     * @expected
+     * - it should return 0 native token balance
+     */
+    it('should return 0 for empty address', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { id } = data;
+        return Promise.resolve({
+          data: {
+            result: [],
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      const result = await network.getAddressAssets('empty-address');
+
+      expect(result.nativeToken).toEqual(0n);
+      expect(result.tokens).toEqual([]);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getAddressAssets` should include mempool transactions (minconf=0)
+     * @dependencies
+     * @scenario
+     * - verify that the RPC call uses minconf=0 to include unconfirmed txs
+     * - mock axios and check call parameters
+     * - run test
+     * @expected
+     * - it should call listunspent with minconf=0
+     */
+    it('should include mempool transactions', async () => {
+      axiosInstance.post.mockImplementation((url, data) => {
+        const { method, params, id } = data;
+
+        // Verify the call is made with minconf=0
+        if (method === 'listunspent') {
+          expect(params[0]).toEqual(0); // minconf should be 0
+        }
+
+        return Promise.resolve({
+          data: {
+            result: [{ amount: 1.0 }],
+            error: null,
+            id: id,
+          },
+        });
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      await network.getAddressAssets(testData.lockAddress);
+
+      expect(axiosInstance.post).toHaveBeenCalled();
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getAddressAssets` should throw FailedError on API error
+     * @dependencies
+     * @scenario
+     * - mock axios to return error
+     * - run test
+     * @expected
+     * - it should throw FailedError
+     */
+    it('should throw FailedError on API error', async () => {
+      axiosInstance.post.mockRejectedValueOnce({
+        response: {
+          data: {
+            error: {
+              code: -5,
+              message: 'Invalid address',
+            },
+          },
+        },
+      });
+
+      const network = new FiroRpcNetwork(URL);
+      await expect(network.getAddressAssets('invalid-address')).rejects.toThrow(
+        FailedError,
+      );
+    });
+  });
+
+  describe('getActualTxId', () => {
+    /**
+     * @target `FiroRpcNetwork.getActualTxId` should return the same hash
+     * @dependencies
+     * @scenario
+     * - call getActualTxId with a transaction hash
+     * - check returned value
+     * @expected
+     * - it should return the same hash (identity function for Bitcoin-like chains)
+     */
+    it('should return the same hash (identity function)', async () => {
+      const network = new FiroRpcNetwork(URL);
+      const hash = testData.txId;
+      const result = await network.getActualTxId(hash);
+
+      expect(result).toEqual(hash);
+    });
+
+    /**
+     * @target `FiroRpcNetwork.getActualTxId` should work with any hash string
+     * @dependencies
+     * @scenario
+     * - call getActualTxId with various hash formats
+     * - check returned values
+     * @expected
+     * - it should always return the input unchanged
+     */
+    it('should work with any hash string', async () => {
+      const network = new FiroRpcNetwork(URL);
+      const testHashes = [
+        'abc123',
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        testData.blockHash,
+      ];
+
+      for (const hash of testHashes) {
+        const result = await network.getActualTxId(hash);
+        expect(result).toEqual(hash);
+      }
+    });
+  });
+});

--- a/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
+++ b/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
@@ -713,6 +713,13 @@ describe('FiroRpcNetwork', () => {
       // Total: 17.75 FIRO = 1775000000 satoshis
       expect(result.nativeToken).toEqual(1775000000n);
       expect(result.tokens).toEqual([]); // Firo doesn't support tokens
+      expect(axiosInstance.post).toHaveBeenCalledWith(
+        '',
+        expect.objectContaining({
+          method: 'listunspent',
+          params: [1, 9999999, [testData.lockAddress]],
+        }),
+      );
     });
 
     /**

--- a/packages/networks/firo-rpc/tests/mocked/rateLimitedAxios.mock.ts
+++ b/packages/networks/firo-rpc/tests/mocked/rateLimitedAxios.mock.ts
@@ -1,0 +1,17 @@
+import RateLimitedAxios from '@rosen-clients/rate-limited-axios';
+
+export const axiosInstance = {
+  get: vi.fn(),
+  post: vi.fn(),
+};
+
+/**
+ * resets axios functions mocks and call counts
+ */
+export const resetAxiosMock = () => {
+  axiosInstance.get.mockReset();
+  axiosInstance.post.mockReset();
+
+  // Mock axios.create to return our mocked instance
+  vi.spyOn(RateLimitedAxios, 'create').mockReturnValue(axiosInstance as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+};

--- a/packages/networks/firo-rpc/tests/testData.ts
+++ b/packages/networks/firo-rpc/tests/testData.ts
@@ -1,0 +1,292 @@
+export const lockAddress = 'DHTom1rFwsgAn5raKU1nok8E5MdQ4GBkAN';
+export const lockAddressPublicKey =
+  '76a914872b67c8270a9eaf5c2abf632af3dea989d2e37188ac';
+
+// RPC response for blockchain info
+export const blockHeightResponse = {
+  result: {
+    chain: 'main',
+    blocks: 5693743,
+    headers: 5693743,
+    bestblockhash:
+      '491256bdad2121de4a07e640795398f92da33e6082bab6c2c859f2be2a48ad1a',
+    difficulty: 53216508.58110767,
+    mediantime: 1746280884,
+    verificationprogress: 0.9999990831244884,
+    initialblockdownload: false,
+    chainwork:
+      '000000000000000000000000000000000000000000001b0199aba077b02aadc8',
+    size_on_disk: 189137123969,
+    pruned: false,
+    softforks: [
+      {
+        id: 'bip34',
+        version: 2,
+        reject: {
+          status: true,
+        },
+      },
+      {
+        id: 'bip66',
+        version: 3,
+        reject: {
+          status: true,
+        },
+      },
+      {
+        id: 'bip65',
+        version: 4,
+        reject: {
+          status: true,
+        },
+      },
+    ],
+    bip9_softforks: {
+      csv: {
+        status: 'failed',
+        startTime: 1462060800,
+        timeout: 1493596800,
+        since: 1703520,
+      },
+    },
+    warnings: '',
+  },
+  error: null,
+  id: 'getinfo_request',
+};
+
+// Block hash for testing
+export const blockHash =
+  '491256bdad2121de4a07e640795398f92da33e6082bab6c2c859f2be2a48ad1a';
+
+// RPC response for a block
+export const blockResponse = {
+  result: {
+    hash: '491256bdad2121de4a07e640795398f92da33e6082bab6c2c859f2be2a48ad1a',
+    confirmations: 2,
+    strippedsize: 18188,
+    size: 18188,
+    weight: 72752,
+    height: 5693743,
+    version: 6422788,
+    versionHex: '00620104',
+    merkleroot:
+      '99b7688dd7d3cc9e0871031677d7e32c067d333927ec728986c0d0b7ef0c94ca',
+    tx: [
+      '7b110de3db716e12de71ca59216a84c985c2f5e5c50ae783d2677d9c0df60658',
+      '6891a81de933788e1ca8f4735054a86ec4ddf5d768a9dc9057c8d707ea1a9a30',
+      '35b8fd16ecc0553c81c980f5e8355d19dbfb1e3306aa3c7f0b8861178a46125a',
+      '788dace4245c70eba4471addd16b545da1f8b36469e3e69580af330745add5e8',
+      '27856d2df08f9e34e0b7676e6e51bbf43a448f5bdb816c7c1ebe51ca1bc06834',
+      '6889495f54698c6306339fe3609f9e1d1cb78319f3345f91394f5f3ef6ad7804',
+      'c63556a9dce4b2520d72fee915bcd3fc41783538768152933866bd867060fa0c',
+      'caa9dd2e997e58444e04d4a362a86411905d6260c803e9348fa203596f330ef8',
+      '08ba4e8df2244f339944f66a636fb3ec312ee7ae69041d0928f1ebcb95b47887',
+      'c42166250fe4f161b2cd5168fe4c18592c5d8322553ae7a815e999e864753427',
+    ],
+    time: 1746281170,
+    mediantime: 1746280884,
+    nonce: 0,
+    bits: '1950b4c9',
+    difficulty: 53216508.58110767,
+    chainwork:
+      '000000000000000000000000000000000000000000001b0199aba077b02aadc8',
+    previousblockhash:
+      'cdb5f24555323bd352c17385ab8b9bf32362c19d8b141430acd2c01250892233',
+    nextblockhash:
+      '2620dc978e666924e772d88745bae437a5587f4292e3969fce76dc8aa618eeb8',
+  },
+  error: null,
+  id: 'getblock_request',
+};
+
+// Block info object for testing
+export const blockInfo = {
+  hash: '491256bdad2121de4a07e640795398f92da33e6082bab6c2c859f2be2a48ad1a',
+  parentHash:
+    'cdb5f24555323bd352c17385ab8b9bf32362c19d8b141430acd2c01250892233',
+  height: 5693743,
+};
+
+// Transaction ID for testing
+export const txId =
+  '19774cdc6bc663926590dc2fe7bfe77ba57a5343aaa16db5ffc377e95663fd4e';
+
+// Block hash for the transaction
+export const txBlockHash =
+  '491256bdad2121de4a07e640795398f92da33e6082bab6c2c859f2be2a48ad1a';
+
+// RPC response for a transaction
+export const txResponse = {
+  result: {
+    hex: '0100000001334a2a5e41047070a5497cf208b3c408998bc4be3487b8125e244bbfb742d915000000006b483045022100dce96e89af41443891626f059ab6934a5b8ac76de3b6881cdc87a0c1c578cc070220054d44f9b6241fe9fbd10482ae5f285c273025324538a3d7e419d7f3dde69d0d012103dc1945a85a6147ed5da6d6f150e9de002e40c4ff48cca96b488fe74fa9af8a88ffffffff02109e6cd81b0000001976a9144883eb0a391995f422a48595edf7a19af5e0660c88ac3b70f1bd731b00001976a914a17fdccb11e75bf95df8f760fde346357f34c7ec88ac00000000',
+    txid: '87ce994dacf48d97dcffd30221f70acf8c2b40ba4d5ed9be8615d79daf922c73',
+    hash: '87ce994dacf48d97dcffd30221f70acf8c2b40ba4d5ed9be8615d79daf922c73',
+    size: 226,
+    vsize: 226,
+    version: 1,
+    locktime: 0,
+    vin: [
+      {
+        txid: '15d942b7bf4b245e12b88734bec48b9908c4b308f27c49a5707004415e2a4a33',
+        vout: 0,
+        scriptSig: {
+          asm: '3045022100dce96e89af41443891626f059ab6934a5b8ac76de3b6881cdc87a0c1c578cc070220054d44f9b6241fe9fbd10482ae5f285c273025324538a3d7e419d7f3dde69d0d[ALL] 03dc1945a85a6147ed5da6d6f150e9de002e40c4ff48cca96b488fe74fa9af8a88',
+          hex: '483045022100dce96e89af41443891626f059ab6934a5b8ac76de3b6881cdc87a0c1c578cc070220054d44f9b6241fe9fbd10482ae5f285c273025324538a3d7e419d7f3dde69d0d012103dc1945a85a6147ed5da6d6f150e9de002e40c4ff48cca96b488fe74fa9af8a88',
+        },
+        sequence: 4294967295,
+      },
+    ],
+    vout: [
+      {
+        value: 1195.95114,
+        n: 0,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 4883eb0a391995f422a48595edf7a19af5e0660c OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a9144883eb0a391995f422a48595edf7a19af5e0660c88ac',
+          reqSigs: 1,
+          type: 'pubkeyhash',
+          addresses: ['DBkXDuHLVa7a6jwaYm1qnsHqQbyaPcHFXk'],
+        },
+      },
+      {
+        value: 301839.21905723,
+        n: 1,
+        scriptPubKey: {
+          asm: 'OP_DUP OP_HASH160 a17fdccb11e75bf95df8f760fde346357f34c7ec OP_EQUALVERIFY OP_CHECKSIG',
+          hex: '76a914a17fdccb11e75bf95df8f760fde346357f34c7ec88ac',
+          reqSigs: 1,
+          type: 'pubkeyhash',
+          addresses: ['DKs2WBbiaAEe9RGzQTmtJj1o9bqsKTUTtC'],
+        },
+      },
+    ],
+    blockhash:
+      'e9fd23982c29992396081fd391389f7648a14bd0ecd6efee22156c856743fbee',
+    confirmations: 4351,
+    time: 1746084906,
+    blocktime: 1746084906,
+  },
+  error: null,
+  id: '19774cdc6bc663926590dc2fe7bfe77ba57a5343aaa16db5ffc377e95663fd4e',
+};
+// Transaction confirmation count
+export const txConfirmation = 3;
+
+// Response for transaction not in mempool
+export const txNotInMempoolResponse = {
+  result: null,
+  error: {
+    code: -5,
+    message: 'Transaction not in mempool',
+  },
+  id: 'mempool_request',
+};
+
+// UTXO response for testing
+export const txOutResponse = {
+  result: {
+    bestblock:
+      '7ece87585c3bda22c8357efaabfe1b4264ccb23360dee49a779a41c9865c5fb1',
+    confirmations: 4,
+    value: 10025.96814264,
+    scriptPubKey: {
+      asm: 'OP_DUP OP_HASH160 212da786d4574d8401d73ac295f34a9ebd98386b OP_EQUALVERIFY OP_CHECKSIG',
+      hex: '76a914212da786d4574d8401d73ac295f34a9ebd98386b88ac',
+      reqSigs: 1,
+      type: 'pubkeyhash',
+      addresses: ['D8AXXiGEZeZnMKTKnC9AWB3YUU4jfMAmYU'],
+    },
+    version: 1,
+    coinbase: true,
+  },
+  error: null,
+  id: 'gettxout_request',
+};
+
+// Fee estimation response
+export const estimateSmartFeeResponse = {
+  result: {
+    feerate: 0.01001657,
+    blocks: 10,
+  },
+  error: null,
+  id: 'fee_request',
+};
+
+// Transaction hex response
+export const txHexResponse = {
+  result:
+    '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff35032fe1560fe4b883e5bda9e7a59ee4bb99e9b1bc205b323032352d30352d30335431343a30363a31302e3532393530363039345a5dffffffff01b84d6d6fe90000001976a914212da786d4574d8401d73ac295f34a9ebd98386b88ac00000000',
+  error: null,
+  id: 'gettxhex_request',
+};
+
+// Firo transaction object
+export const firoTx = {
+  id: '87ce994dacf48d97dcffd30221f70acf8c2b40ba4d5ed9be8615d79daf922c73',
+  inputs: [
+    {
+      txId: '15d942b7bf4b245e12b88734bec48b9908c4b308f27c49a5707004415e2a4a33',
+      index: 0,
+      scriptPubKey:
+        '483045022100dce96e89af41443891626f059ab6934a5b8ac76de3b6881cdc87a0c1c578cc070220054d44f9b6241fe9fbd10482ae5f285c273025324538a3d7e419d7f3dde69d0d012103dc1945a85a6147ed5da6d6f150e9de002e40c4ff48cca96b488fe74fa9af8a88',
+    },
+  ],
+  outputs: [
+    {
+      value: 119595114000n, // Value in satoshis (1195.95114000 FIRO)
+      scriptPubKey: '76a9144883eb0a391995f422a48595edf7a19af5e0660c88ac',
+    },
+    {
+      value: 30183921905723n, // Value in satoshis (301839.21905723 FIRO)
+      scriptPubKey: '76a914a17fdccb11e75bf95df8f760fde346357f34c7ec88ac',
+    },
+  ],
+};
+
+// UTXO object
+export const firoUtxo = {
+  txId: '19774cdc6bc663926590dc2fe7bfe77ba57a5343aaa16db5ffc377e95663fd4e',
+  index: 0,
+  value: 119595114000n, // Value in satoshis (10025.96814264 FIRO)
+};
+
+// Include these for compatibility with existing tests
+export const firoPaymentBytes =
+  '70736274ff0100b30200000001349ef262b9716ba26f5ddf04f9917e3149e16304a8b8b99de6b1e338dee297850200000000ffffffff030000000000000000356a33000000000005f5e10000000000009896802103e5bedab3f782ef17a73e9bdc41ee0e18c3ab477400f35bcf7caa54171db7ff3600ca9a3b0000000017a914d4c141068ab3a242aed5081a27ac3f10ad99ac9887c8e7ee5f030000001976a914872b67c8270a9eaf5c2abf632af3dea989d2e37188ac00000000000100fd1d010200000001349ef262b9716ba26f5ddf04f9917e3149e16304a8b8b99de6b1e338dee29785020000006a47304402207e4cd2745243257f0749b4a41425c2075dfb199f47072bfbf7db14b02677a8ae02204682c5159737314f7c4ba0f7112876497171a7cee48dddf667dccd59cf8ae1280121022b9ed0a9139042921decc62603a4a07357b444da2e0bd6a96c27155117913037ffffffff030000000000000000356a33000000000005f5e10000000000009896802103e5bedab3f782ef17a73e9bdc41ee0e18c3ab477400f35bcf7caa54171db7ff3600ca9a3b0000000017a914d4c141068ab3a242aed5081a27ac3f10ad99ac9887c8e7ee5f030000001976a914872b67c8270a9eaf5c2abf632af3dea989d2e37188ac0000000000000000';
+
+export const unsignedTxId = 'unsigned_tx_id_placeholder';
+export const addressBalance = 13184394312n;
+
+export const unconfirmedTxResponse = {
+  block_height: -1,
+  block_index: -1,
+  hash: 'f463bf88dbdeb8af5bc26b3ba1beb7e4712303846d73d880c280440dca13e1ef',
+  confirmations: 0,
+};
+
+export const emptyAddressResponse = {
+  address: 'DNEvVDq17mQiV46XQgf5NAQyvQbY92z6cg',
+  total_received: 0,
+  total_sent: 0,
+  balance: 0,
+  unconfirmed_balance: 0,
+  final_balance: 0,
+  n_tx: 0,
+  unconfirmed_n_tx: 0,
+  final_n_tx: 0,
+};
+
+export const unusedAddressResponse = {
+  address: 'D5XR2ByNV9qSNXq4B1krZoGpZ3VXfzwpU6',
+  total_received: 0,
+  total_sent: 0,
+  balance: 0,
+  unconfirmed_balance: 0,
+  final_balance: 0,
+  n_tx: 0,
+  unconfirmed_n_tx: 0,
+  final_n_tx: 0,
+  txs: [],
+};

--- a/packages/networks/firo-rpc/tests/testData.ts
+++ b/packages/networks/firo-rpc/tests/testData.ts
@@ -290,3 +290,51 @@ export const unusedAddressResponse = {
   final_n_tx: 0,
   txs: [],
 };
+
+// Mock UTXOs for getAddressBoxes test
+export const mockAddressUtxos = [
+  {
+    txid: txId,
+    vout: 0,
+    address: lockAddress,
+    scriptPubKey: lockAddressPublicKey,
+    amount: 10.5,
+    confirmations: 10,
+  },
+  {
+    txid: '2nd-tx-id',
+    vout: 1,
+    address: lockAddress,
+    scriptPubKey: lockAddressPublicKey,
+    amount: 5.25,
+    confirmations: 5,
+  },
+  {
+    txid: '3rd-tx-id',
+    vout: 0,
+    address: lockAddress,
+    scriptPubKey: lockAddressPublicKey,
+    amount: 2.0,
+    confirmations: 3,
+  },
+];
+
+// Expected output for getAddressBoxes test (first 2 UTXOs)
+export const expectedAddressBoxes = [
+  {
+    txId: txId,
+    index: 0,
+    value: 1050000000n, // 10.5 FIRO in satoshis
+  },
+  {
+    txId: '2nd-tx-id',
+    index: 1,
+    value: 525000000n, // 5.25 FIRO in satoshis
+  },
+];
+
+// Expected confirmation count (should match txResponse.result.confirmations)
+export const expectedTxConfirmation = 4351;
+
+// Total balance for address assets (sum of all mock UTXOs)
+export const expectedAddressBalance = 1775000000n; // 17.75 FIRO in satoshis

--- a/packages/networks/firo-rpc/tsconfig.build.json
+++ b/packages/networks/firo-rpc/tsconfig.build.json
@@ -6,6 +6,6 @@
   "exclude": ["tests", "vitest.config.ts"],
   "references": [
     { "path": "../../abstract-chain/tsconfig.build.json" },
-    { "path": "../../chains/doge/tsconfig.build.json" }
+    { "path": "../../chains/firo/tsconfig.build.json" }
   ]
 }

--- a/packages/networks/firo-rpc/tsconfig.build.json
+++ b/packages/networks/firo-rpc/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./lib"
+  },
+  "exclude": ["tests", "vitest.config.ts"],
+  "references": [
+    { "path": "../../abstract-chain/tsconfig.build.json" },
+    { "path": "../../chains/doge/tsconfig.build.json" }
+  ]
+}

--- a/packages/networks/firo-rpc/tsconfig.json
+++ b/packages/networks/firo-rpc/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "types": ["node", "vitest/globals"]
   },
-  "include": ["tests", "lib", "vitest.config.ts"],
+  "include": ["tests", "lib"],
   "references": [
     { "path": "../../abstract-chain" },
-    { "path": "../../chains/doge" }
+    { "path": "../../chains/firo" }
   ]
 }

--- a/packages/networks/firo-rpc/tsconfig.json
+++ b/packages/networks/firo-rpc/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["tests", "lib", "vitest.config.ts"],
+  "references": [
+    { "path": "../../abstract-chain" },
+    { "path": "../../chains/doge" }
+  ]
+}

--- a/packages/networks/firo-rpc/vitest.config.ts
+++ b/packages/networks/firo-rpc/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    coverage: {
+      all: true,
+      provider: 'istanbul',
+      reporter: 'cobertura',
+    },
+    passWithNoTests: true,
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/packages/networks/firo-rpc/vitest.config.ts
+++ b/packages/networks/firo-rpc/vitest.config.ts
@@ -1,18 +1,5 @@
-import { defineConfig } from 'vitest/config';
+import { defineProject, mergeConfig } from 'vitest/config';
 
-export default defineConfig({
-  test: {
-    globals: true,
-    coverage: {
-      all: true,
-      provider: 'istanbul',
-      reporter: 'cobertura',
-    },
-    passWithNoTests: true,
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
-  },
-});
+import configShared from '../../../vitest.shared';
+
+export default mergeConfig(configShared, defineProject({}));


### PR DESCRIPTION
Depends on: https://github.com/rosen-bridge/guard-service/pull/4

Adds the `@rosen-chains/firo-rpc` package to serve as a network API provider for the Firo blockchain. This implementation interacts directly with Firo nodes via JSON-RPC to handle block retrieval, transaction submission, and UTXO management.