### PR TITLE
fix(firo): change fee rate divisor from 1024 to 1000

### DIFF
--- a/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
+++ b/packages/networks/firo-rpc/lib/firoRpcNetwork.ts
@@ -421,7 +421,7 @@ class FiroRpcNetwork extends AbstractFiroNetwork {
 
       this.validateResponseId(randomId, response.data.id);
       const feeSatoshis = this.convertToSatoshis(response.data.result.feerate);
-      const feeRate = Number(feeSatoshis) / 1024;
+      const feeRate = Number(feeSatoshis) / 1000;
 
       this.logger.debug(
         `Requested 'estimatesmartfee'. Response: ${JsonBigInt.stringify(

--- a/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
+++ b/packages/networks/firo-rpc/tests/firoRpcNetwork.spec.ts
@@ -334,7 +334,7 @@ describe('FiroRpcNetwork', () => {
 
       // Convert FIRO/kB to satoshis/byte
       const expectedFeeRate = Math.ceil(
-        (testData.estimateSmartFeeResponse.result.feerate * 100000000) / 1024,
+        (testData.estimateSmartFeeResponse.result.feerate * 100000000) / 1000,
       );
       expect(result).toEqual(expectedFeeRate);
     });


### PR DESCRIPTION
## Description
  Changes the fee rate calculation divisor from 1024 to 1000 for Firo to match the actual
  Firo implementation.

  ## Background
  Firo's RPC returns fee rates in BTC per kilobyte, where "kilobyte" uses the SI
  definition (1000 bytes), not the binary definition (1024 bytes). This is confirmed in
  Firo's source code:
  - `CFeeRate::nSatoshisPerK` is defined as "satoshis-per-1,000-bytes"
  - `GetFee()` divides by 1000, not 1024

  ## Changes
  - **UI**: Updated `getFeeRatio()` in `networks/firo/src/utils.ts` (3 instances)
  - **Guard-service**: Updated `getFeeRatio()` in `packages/networks/firo-rpc/lib/
  firoRpcNetwork.ts`
  - **Tests**: Updated test expectations in `packages/networks/firo-rpc/tests/
  firoRpcNetwork.spec.ts`

  ## Impact
  - Fixes ~2.4% fee underestimation
  - Transactions will now use correct fee rates matching Firo network expectations
  - Improves transaction confirmation times